### PR TITLE
Feature/cleanup test2code tables on build deletion (#292)

### DIFF
--- a/admin-core/src/main/kotlin/com/epam/drill/admin/plugin/Senders.kt
+++ b/admin-core/src/main/kotlin/com/epam/drill/admin/plugin/Senders.kt
@@ -56,6 +56,7 @@ class PluginSenders(override val di: DI) : DIAware {
             logger.trace { "send destination $dest for $destination" }
             val subscription = context.toSubscription()
             val messageKey = subscription.toKey(dest)
+            val agentKey = subscription.toAgentKey()
             val pluginCache = pluginCaches.get(pluginId, subscription, true)
 
             //TODO EPMDJ-6817 replace with normal event removal.
@@ -71,7 +72,7 @@ class PluginSenders(override val di: DI) : DIAware {
                 pluginStoresDSM(pluginId).let { store ->
                     withContext(Dispatchers.IO) {
                         measureTimedValue {
-                            store.storeMessage(messageKey, message)
+                            store.storeMessage(messageKey, message, agentKey)
                         }.let {
                             logger.trace { "Stored message (key=$messageKey, size=${it.value}) in ${it.duration}" }
                         }

--- a/admin-core/src/main/kotlin/com/epam/drill/admin/websocket/Subscriptions.kt
+++ b/admin-core/src/main/kotlin/com/epam/drill/admin/websocket/Subscriptions.kt
@@ -26,6 +26,12 @@ fun Subscription?.toKey(destination: String): String = when (this) {
     null -> destination
 }
 
+fun Subscription?.toAgentKey(): String = when (this) {
+    is AgentSubscription -> "${agentKeyPattern(agentId, buildVersion, filterId)}"
+    is GroupSubscription -> "$groupPrefix$groupId"
+    null -> throw IllegalArgumentException("Invalid subscription type.")
+}
+
 internal fun agentKeyPattern(
     agentId: String,
     buildVersion: String?,

--- a/admin-core/src/test/kotlin/com/epam/drill/admin/store/MessagePersistingTest.kt
+++ b/admin-core/src/test/kotlin/com/epam/drill/admin/store/MessagePersistingTest.kt
@@ -43,7 +43,7 @@ class MessagePersistingTest {
         val message = SimpleMessage("data")
         runBlocking {
             assertNull(storeClient.readMessage("1"))
-            storeClient.storeMessage("1", message)
+            storeClient.storeMessage("1", message, "test")
             assertEquals(message, storeClient.readMessage("1"))
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ mapdbVersion = 3.0.8
 postgresEmbeddedVersion = 2.10
 jibVersion = 3.1.4
 
-sharedLibsRef = feature/delete-build-cleanup-t2c-tables
+sharedLibsRef = main
 sharedLibsLocalPath = lib-jvm-shared
 loggerSkipJvmTests = false
 testsSkipIntegrationTests = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ mapdbVersion = 3.0.8
 postgresEmbeddedVersion = 2.10
 jibVersion = 3.1.4
 
-sharedLibsRef = main
+sharedLibsRef = feature/delete-build-cleanup-t2c-tables
 sharedLibsLocalPath = lib-jvm-shared
 loggerSkipJvmTests = false
 testsSkipIntegrationTests = false


### PR DESCRIPTION
TODO: fix Integration tests:
MultipleAgentRegistrationTest > 4 Agents should be registered in parallel() FAILED
    org.opentest4j.AssertionFailedError at MultipleAgentRegistrationTest.kt:39

_________________________________________________________________________________________________________________________________
* dsm-debug

* feat!: add agentKey to Binarya table

N.B: decode fails for BynariaData.

* feat: add BinarySerializer

* fix: change version related to pushed tags

* fix: change version for EPMDJ-10551

* fix: code convention

* build: set dsm version to support build data deletion

---------