### PR TITLE
fix: reject processData message if currentBuild version doesnt match connected agent build version

### DIFF
--- a/admin-core/src/main/kotlin/com/epam/drill/admin/endpoints/plugin/PluginDispatcher.kt
+++ b/admin-core/src/main/kotlin/com/epam/drill/admin/endpoints/plugin/PluginDispatcher.kt
@@ -79,7 +79,7 @@ internal class PluginDispatcher(override val di: DI) : DIAware {
         plugins[pluginId]?.let {
             val agentEntry = agentManager.entryOrNull(agentInfo.id)!!
             agentEntry[pluginId]?.run {
-                processData(instanceId, message.drillMessage.content)
+                processData(instanceId, agentInfo.build.version, message.drillMessage.content)
             } ?: logger.error { "Plugin $pluginId not initialized for agent ${agentInfo.id}!" }
         } ?: logger.error { "Plugin $pluginId not loaded!" }
     }

--- a/test2code-admin/src/main/kotlin/com/epam/drill/plugins/test2code/Plugin.kt
+++ b/test2code-admin/src/main/kotlin/com/epam/drill/plugins/test2code/Plugin.kt
@@ -319,8 +319,11 @@ class Plugin(
      */
     override suspend fun processData(
         instanceId: String,
+        attachedAgentBuildVersion: String,
         content: String,
     ): Any = run {
+        if (attachedAgentBuildVersion != buildVersion) return "";
+
         val message = if (content.isJson())
             json.decodeFromString(CoverMessage.serializer(), content)
         else {


### PR DESCRIPTION
fix: reject processData message if currentBuild version doesnt match connected agent build version

WHY: in case when two or more agents are deployed with different versions coverage from "older" version is written to "newer" version by mistake