### PR TITLE
Feature/oauth2 user mapping epmdj 10714

### DIFF
--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/config/OAuthConfig.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/config/OAuthConfig.kt
@@ -60,7 +60,7 @@ class OAuthConfig(private val config: ApplicationConfig) {
     val tokenMapping: UserMapping
         get() = oauth2.config("tokenMapping").run {
             UserMapping(
-                username = propertyOrNull("username")?.getString() ?: "sub",
+                username = propertyOrNull("username")?.getString() ?: "sub", //see https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
                 roles = propertyOrNull("roles")?.getString()
             )
         }

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/config/OAuthConfig.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/config/OAuthConfig.kt
@@ -59,7 +59,7 @@ class OAuthConfig(private val config: ApplicationConfig) {
     val tokenMapping: UserMapping
         get() = oauth2.config("tokenMapping").run {
             UserMapping(
-                username = propertyOrNull("username")?.getString() ?: "username",
+                username = propertyOrNull("username")?.getString() ?: "sub",
                 roles = propertyOrNull("roles")?.getString() ?: "roles"
             )
         }

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/config/OAuthConfig.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/config/OAuthConfig.kt
@@ -15,6 +15,7 @@
  */
 package com.epam.drill.admin.auth.config
 
+import com.epam.drill.admin.auth.principal.Role
 import io.ktor.config.*
 
 class OAuthConfig(private val config: ApplicationConfig) {
@@ -60,7 +61,7 @@ class OAuthConfig(private val config: ApplicationConfig) {
         get() = oauth2.config("tokenMapping").run {
             UserMapping(
                 username = propertyOrNull("username")?.getString() ?: "sub",
-                roles = propertyOrNull("roles")?.getString() ?: "roles"
+                roles = propertyOrNull("roles")?.getString()
             )
         }
 
@@ -68,18 +69,18 @@ class OAuthConfig(private val config: ApplicationConfig) {
         get() = oauth2.config("userInfoMapping").run {
             UserMapping(
                 username = propertyOrNull("username")?.getString() ?: "username",
-                roles = propertyOrNull("roles")?.getString() ?: "roles"
+                roles = propertyOrNull("roles")?.getString()
             )
         }
 
     val roleMapping: RoleMapping
         get() = oauth2.config("roleMapping").run {
             RoleMapping(
-                user = propertyOrNull("user")?.getString() ?: "USER",
-                admin = propertyOrNull("admin")?.getString() ?: "ADMIN"
+                user = propertyOrNull("user")?.getString() ?: Role.USER.name,
+                admin = propertyOrNull("admin")?.getString() ?: Role.ADMIN.name
             )
         }
 }
 
-data class UserMapping(val username: String, val roles: String)
+data class UserMapping(val username: String, val roles: String?)
 data class RoleMapping(val user: String, val admin: String)

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/config/OAuthConfig.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/config/OAuthConfig.kt
@@ -55,4 +55,31 @@ class OAuthConfig(private val config: ApplicationConfig) {
 
     val uiRootPath: String
         get() = ui.propertyOrNull("rootPath")?.getString() ?: "/"
+
+    val tokenMapping: UserMapping
+        get() = oauth2.config("tokenMapping").run {
+            UserMapping(
+                username = propertyOrNull("username")?.getString() ?: "username",
+                roles = propertyOrNull("roles")?.getString() ?: "roles"
+            )
+        }
+
+    val userInfoMapping: UserMapping
+        get() = oauth2.config("userInfoMapping").run {
+            UserMapping(
+                username = propertyOrNull("username")?.getString() ?: "username",
+                roles = propertyOrNull("roles")?.getString() ?: "roles"
+            )
+        }
+
+    val roleMapping: RoleMapping
+        get() = oauth2.config("roleMapping").run {
+            RoleMapping(
+                user = propertyOrNull("user")?.getString() ?: "USER",
+                admin = propertyOrNull("admin")?.getString() ?: "ADMIN"
+            )
+        }
 }
+
+data class UserMapping(val username: String, val roles: String)
+data class RoleMapping(val user: String, val admin: String)

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/config/OAuthConfig.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/config/OAuthConfig.kt
@@ -36,8 +36,8 @@ class OAuthConfig(private val config: ApplicationConfig) {
     val accessTokenUrl: String
         get() = oauth2.property("accessTokenUrl").getString()
 
-    val userInfoUrl: String
-        get() = oauth2.property("userInfoUrl").getString()
+    val userInfoUrl: String?
+        get() = oauth2.propertyOrNull("userInfoUrl")?.getString()
 
     val clientId: String
         get() = oauth2.property("clientId").getString()

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/config/OAuthModule.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/config/OAuthModule.kt
@@ -15,8 +15,10 @@
  */
 package com.epam.drill.admin.auth.config
 
+import com.epam.drill.admin.auth.service.OAuthMapper
 import com.epam.drill.admin.auth.service.OAuthService
 import com.epam.drill.admin.auth.service.TokenService
+import com.epam.drill.admin.auth.service.impl.OAuthMapperImpl
 import com.epam.drill.admin.auth.service.impl.OAuthServiceImpl
 import com.epam.drill.admin.auth.service.transaction.TransactionalOAuthService
 import io.ktor.application.*
@@ -47,10 +49,12 @@ val oauthDIModule = DI.Module("oauth") {
 fun DI.Builder.configureOAuthDI() {
     bind<HttpClient>("oauthHttpClient") with singleton { HttpClient(Apache) }
     bind<OAuthConfig>() with singleton { OAuthConfig(instance<Application>().environment.config) }
+    bind<OAuthMapper>() with singleton { OAuthMapperImpl(instance()) }
     bind<OAuthService>() with singleton { TransactionalOAuthService(OAuthServiceImpl(
         httpClient = instance("oauthHttpClient"),
         oauthConfig = instance(),
-        userRepository = instance()))
+        userRepository = instance(),
+        oauthMapper = instance()))
     }
 }
 

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/OAuthMapper.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/OAuthMapper.kt
@@ -18,7 +18,7 @@ package com.epam.drill.admin.auth.service
 import com.epam.drill.admin.auth.entity.UserEntity
 
 interface OAuthMapper {
-    fun mergeUserEntities(userFromDatabase: UserEntity, userFromOAuth: UserEntity): UserEntity
+    fun updateDatabaseUserEntity(userFromDatabase: UserEntity, userFromOAuth: UserEntity): UserEntity
 
     fun mapUserInfoToUserEntity(userInfoResponse: String): UserEntity
 

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/OAuthMapper.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/OAuthMapper.kt
@@ -1,0 +1,11 @@
+package com.epam.drill.admin.auth.service
+
+import com.epam.drill.admin.auth.entity.UserEntity
+
+interface OAuthMapper {
+    fun mergeUserEntities(userFromDatabase: UserEntity, userFromOAuth: UserEntity): UserEntity
+
+    fun mapUserInfoToUserEntity(userInfoResponse: String): UserEntity
+
+    fun mapAccessTokenToUserEntity(accessToken: String): UserEntity
+}

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/OAuthMapper.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/OAuthMapper.kt
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2020 - 2022 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.epam.drill.admin.auth.service
 
 import com.epam.drill.admin.auth.entity.UserEntity

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/OAuthMapper.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/OAuthMapper.kt
@@ -22,5 +22,5 @@ interface OAuthMapper {
 
     fun mapUserInfoToUserEntity(userInfoResponse: String): UserEntity
 
-    fun mapAccessTokenToUserEntity(accessToken: String): UserEntity
+    fun mapAccessTokenPayloadToUserEntity(accessToken: String): UserEntity
 }

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/OAuthMapperImpl.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/OAuthMapperImpl.kt
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2020 - 2022 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.epam.drill.admin.auth.service.impl
 
 import com.auth0.jwt.JWT

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/OAuthMapperImpl.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/OAuthMapperImpl.kt
@@ -1,0 +1,64 @@
+package com.epam.drill.admin.auth.service.impl
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.interfaces.DecodedJWT
+import com.epam.drill.admin.auth.config.OAuthConfig
+import com.epam.drill.admin.auth.config.OAuthUnauthorizedException
+import com.epam.drill.admin.auth.entity.UserEntity
+import com.epam.drill.admin.auth.principal.Role
+import com.epam.drill.admin.auth.service.OAuthMapper
+import kotlinx.serialization.json.*
+
+class OAuthMapperImpl(oauthConfig: OAuthConfig): OAuthMapper {
+    private val userMapping = oauthConfig.userInfoMapping
+    private val roleMapping = oauthConfig.roleMapping
+
+    override fun mergeUserEntities(userFromDatabase: UserEntity, userFromOAuth: UserEntity): UserEntity {
+        return userFromDatabase.copy(
+            role = if (Role.UNDEFINED.name != userFromOAuth.role) userFromOAuth.role else userFromDatabase.role
+        )
+    }
+
+    override fun mapUserInfoToUserEntity(userInfoResponse: String): UserEntity {
+        return Json.parseToJsonElement(userInfoResponse).run {
+            UserEntity(
+                username = getStringValue(userMapping.username),
+                role = mapRole(getStringArray(userMapping.roles)).name
+            )
+        }
+    }
+
+    override fun mapAccessTokenToUserEntity(accessToken: String): UserEntity {
+        return JWT.decode(accessToken).run {
+            UserEntity(
+                username = getStringValue(userMapping.username),
+                role = mapRole(getStringArray(userMapping.roles)).name
+            )
+        }
+    }
+
+    private fun mapRole(roleNames: List<String>?): Role {
+        roleNames?.forEach {
+            when (it.lowercase()) {
+                roleMapping.user.lowercase() -> return Role.USER
+                roleMapping.admin.lowercase() -> return Role.ADMIN
+            }
+        }
+        return Role.UNDEFINED
+    }
+}
+
+private fun JsonElement.getStringValue(key: String): String =
+    this.jsonObject[key]?.jsonPrimitive?.contentOrNull
+        ?: throw OAuthUnauthorizedException("The key \"$key\" is not found in user-info response")
+
+private fun JsonElement.getStringArray(key: String): List<String> =
+    this.jsonObject[key]?.jsonArray?.map { it.jsonPrimitive.content } ?: emptyList()
+
+private fun DecodedJWT.getStringValue(key: String): String =
+    getClaim(key).asString()
+        ?: throw OAuthUnauthorizedException("The claim \"$key\" is not found in access token")
+
+private fun DecodedJWT.getStringArray(key: String): List<String> =
+    getClaim(key).asList(String::class.java)
+

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/OAuthMapperImpl.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/OAuthMapperImpl.kt
@@ -40,7 +40,7 @@ class OAuthMapperImpl(oauthConfig: OAuthConfig) : OAuthMapper {
         return Json.parseToJsonElement(userInfoResponse).toUserEntity(userInfoMapping)
     }
 
-    override fun mapAccessTokenToUserEntity(accessToken: String): UserEntity {
+    override fun mapAccessTokenPayloadToUserEntity(accessToken: String): UserEntity {
         return JWT.decode(accessToken).toUserEntity(tokenMapping)
     }
 

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/OAuthMapperImpl.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/OAuthMapperImpl.kt
@@ -30,7 +30,7 @@ class OAuthMapperImpl(oauthConfig: OAuthConfig) : OAuthMapper {
     private val userInfoMapping = oauthConfig.userInfoMapping
     private val roleMapping = oauthConfig.roleMapping
 
-    override fun mergeUserEntities(userFromDatabase: UserEntity, userFromOAuth: UserEntity): UserEntity {
+    override fun updateDatabaseUserEntity(userFromDatabase: UserEntity, userFromOAuth: UserEntity): UserEntity {
         return userFromDatabase.copy(
             role = if (Role.UNDEFINED.name != userFromOAuth.role) userFromOAuth.role else userFromDatabase.role
         )

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/OAuthServiceImpl.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/OAuthServiceImpl.kt
@@ -42,7 +42,7 @@ class OAuthServiceImpl(
         val oauthUser = oauthConfig.userInfoUrl
             ?.let { getUserInfo(it, principal.accessToken) }
             ?.let { oauthMapper.mapUserInfoToUserEntity(it) }
-            ?: oauthMapper.mapAccessTokenToUserEntity(principal.accessToken)
+            ?: oauthMapper.mapAccessTokenPayloadToUserEntity(principal.accessToken)
         val dbUser = userRepository.findByUsername(oauthUser.username)
         if (dbUser?.blocked == true)
             throw OAuthAccessDeniedException()

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/OAuthServiceImpl.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/OAuthServiceImpl.kt
@@ -94,29 +94,29 @@ private fun UserEntity.toView() = UserInfoView(
 private fun JsonElement.toUserEntity(userMapping: UserMapping, roleMapping: RoleMapping) = UserEntity(
     username = findStringValue(userMapping.username)
         ?: throw OAuthUnauthorizedException("The key \"${userMapping.username}\" is not found in userinfo response"),
-    role = findRole(
+    role = mapRole(
         findStringArray(userMapping.roles),
         roleMapping
-    )?.name
+    ).name
 )
 
 private fun DecodedJWT.toUserEntity(userMapping: UserMapping, roleMapping: RoleMapping) = UserEntity(
     username = getClaim(userMapping.username).asString()
         ?: throw OAuthUnauthorizedException("The claim \"${userMapping.username}\" is not found in access token"),
-    role = findRole(
+    role = mapRole(
         getClaim(userMapping.roles).asList(String::class.java),
         roleMapping
-    )?.name
+    ).name
 )
 
-private fun findRole(roleNames: List<String>?, roleMapping: RoleMapping): Role? {
+private fun mapRole(roleNames: List<String>?, roleMapping: RoleMapping): Role {
     roleNames?.forEach {
         when (it.lowercase()) {
             roleMapping.user.lowercase() -> return Role.USER
             roleMapping.admin.lowercase() -> return Role.ADMIN
         }
     }
-    return null
+    return Role.UNDEFINED
 }
 
 private fun JsonElement.findStringValue(key: String) =

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/OAuthServiceImpl.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/OAuthServiceImpl.kt
@@ -53,7 +53,7 @@ class OAuthServiceImpl(
         dbUser: UserEntity?,
         oauthUser: UserEntity
     ): UserEntity = dbUser
-        ?.let { oauthMapper.mergeUserEntities(dbUser, oauthUser) }
+        ?.let { oauthMapper.updateDatabaseUserEntity(dbUser, oauthUser) }
         ?.apply { userRepository.update(this) }
         ?: userRepository.create(oauthUser)
 

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/OAuthServiceImpl.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/OAuthServiceImpl.kt
@@ -46,12 +46,12 @@ class OAuthServiceImpl(
         val dbUser = userRepository.findByUsername(oauthUser.username)
         if (dbUser?.blocked == true)
             throw OAuthAccessDeniedException()
-        return createOrUpdateUser(oauthUser, dbUser).toView()
+        return createOrUpdateUser(dbUser, oauthUser).toView()
     }
 
     private suspend fun createOrUpdateUser(
-        oauthUser: UserEntity,
-        dbUser: UserEntity?
+        dbUser: UserEntity?,
+        oauthUser: UserEntity
     ): UserEntity = dbUser
         ?.let { oauthMapper.mergeUserEntities(dbUser, oauthUser) }
         ?.apply { userRepository.update(this) }

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthMapperTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthMapperTest.kt
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2020 - 2022 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.epam.drill.admin.auth
 
 import com.auth0.jwt.JWT

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthMapperTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthMapperTest.kt
@@ -1,0 +1,123 @@
+package com.epam.drill.admin.auth
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.epam.drill.admin.auth.config.OAuthConfig
+import com.epam.drill.admin.auth.entity.UserEntity
+import com.epam.drill.admin.auth.principal.Role
+import com.epam.drill.admin.auth.service.impl.OAuthMapperImpl
+import io.ktor.config.*
+import kotlin.test.*
+
+/**
+ * Testing [OAuthMapperImpl]
+ */
+class OAuthMapperTest {
+
+    private val testAlgorithm = Algorithm.HMAC512("secret")
+    private val testUsername = "some-username"
+    private val oauthMapper = OAuthMapperImpl(OAuthConfig(MapApplicationConfig()))
+
+    @Test
+    fun `given token mapping config, mapAccessTokenToUserEntity map access token data to user entity`() {
+        val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
+            put("drill.auth.oauth2.tokenMapping.username", "user_name")
+            put("drill.auth.oauth2.tokenMapping.roles", "realm_roles")
+        })
+        val oauthMapper = OAuthMapperImpl(oauthConfig)
+
+        val userEntity = oauthMapper.mapAccessTokenToUserEntity(
+            JWT.create()
+                .withClaim("user_name", "some-username")
+                .withClaim("realm_roles", listOf("user"))
+                .sign(testAlgorithm)
+        )
+        assertEquals("some-username", userEntity.username)
+        assertEquals(Role.USER.name, userEntity.role)
+    }
+
+    @Test
+    fun `given userinfo mapping config, mapUserInfoToUserEntity map user-info json response to user entity`() {
+        val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
+            put("drill.auth.oauth2.userInfoMapping.username", "user_name")
+        })
+        val oauthMapper = OAuthMapperImpl(oauthConfig)
+
+        val userEntity = oauthMapper.mapUserInfoToUserEntity(
+            """
+                {
+                    "user_name": "some-username",
+                    "roles": ["user"]                                                       
+                }
+            """.trimIndent()
+        )
+        assertEquals("some-username", userEntity.username)
+        assertEquals(Role.USER.name, userEntity.role)
+    }
+
+    @Test
+    fun `given role mapping config, mapAccessTokenToUserEntity map roles from access token to Drill4J roles`() {
+        val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
+            put("drill.auth.oauth2.roleMapping.user", "Dev")
+            put("drill.auth.oauth2.roleMapping.admin", "Ops")
+            put("drill.auth.oauth2.tokenMapping.roles", "roles")
+        })
+        val oauthMapper = OAuthMapperImpl(oauthConfig)
+
+        val userOps = oauthMapper.mapAccessTokenToUserEntity(
+            JWT.create()
+                .withSubject("user-ops")
+                .withClaim("roles", listOf("Ops", "Manager"))
+                .sign(testAlgorithm)
+        )
+        val userDev = oauthMapper.mapAccessTokenToUserEntity(
+            JWT.create()
+                .withSubject("user-dev")
+                .withClaim("roles", listOf("QA", "Dev"))
+                .sign(testAlgorithm)
+        )
+
+        assertEquals(Role.ADMIN.name, userOps.role)
+        assertEquals(Role.USER.name, userDev.role)
+    }
+
+    @Test
+    fun `if roles cannot be matched, mapAccessTokenToUserEntity must return undefined role`() {
+        val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
+            put("drill.auth.oauth2.roleMapping.user", "Dev")
+            put("drill.auth.oauth2.roleMapping.admin", "Ops")
+            put("drill.auth.oauth2.tokenMapping.roles", "roles")
+        })
+        val oauthMapper = OAuthMapperImpl(oauthConfig)
+
+        val userEntity = oauthMapper.mapAccessTokenToUserEntity(
+            JWT.create()
+                .withSubject("some-username")
+                .withClaim("roles", listOf("QA", "Analyst"))
+                .sign(testAlgorithm)
+        )
+
+        assertEquals(Role.UNDEFINED.name, userEntity.role)
+    }
+
+    @Test
+    fun `mergeUserEntities must override Database fields with not null fields from OAuth2`() {
+        val mergedUserEntity = oauthMapper.mergeUserEntities(
+            userFromDatabase = UserEntity(username = testUsername, role = Role.USER.name, id = 123),
+            userFromOAuth = UserEntity(username = testUsername, role = Role.ADMIN.name)
+        )
+
+        assertEquals(Role.ADMIN.name, mergedUserEntity.role)
+        assertEquals(123, mergedUserEntity.id)
+    }
+
+    @Test
+    fun `given undefined role from OAuth2, mergeUserEntities return user entity with role from Database`() {
+        val mergedUserEntity = oauthMapper.mergeUserEntities(
+            userFromDatabase = UserEntity(username = testUsername, role = Role.USER.name),
+            userFromOAuth = UserEntity(username = testUsername, role = Role.UNDEFINED.name)
+        )
+
+        assertEquals(Role.USER.name, mergedUserEntity.role)
+    }
+}

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthMapperTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthMapperTest.kt
@@ -36,14 +36,14 @@ class OAuthMapperTest {
     private val oauthMapper = OAuthMapperImpl(OAuthConfig(MapApplicationConfig()))
 
     @Test
-    fun `given token mapping config, mapAccessTokenToUserEntity must map access token data to user entity`() {
+    fun `given token mapping config, mapAccessTokenPayloadToUserEntity must map access token data to user entity`() {
         val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
             put("drill.auth.oauth2.tokenMapping.username", "user_name")
             put("drill.auth.oauth2.tokenMapping.roles", "realm_roles")
         })
         val oauthMapper = OAuthMapperImpl(oauthConfig)
 
-        val userEntity = oauthMapper.mapAccessTokenToUserEntity(
+        val userEntity = oauthMapper.mapAccessTokenPayloadToUserEntity(
             JWT.create()
                 .withClaim("user_name", "some-username")
                 .withClaim("realm_roles", listOf("user"))
@@ -74,7 +74,7 @@ class OAuthMapperTest {
     }
 
     @Test
-    fun `given role mapping config, mapAccessTokenToUserEntity must map roles from access token to Drill4J roles`() {
+    fun `given role mapping config, mapAccessTokenPayloadToUserEntity must map roles from access token to Drill4J roles`() {
         val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
             put("drill.auth.oauth2.roleMapping.user", "Dev")
             put("drill.auth.oauth2.roleMapping.admin", "Ops")
@@ -82,13 +82,13 @@ class OAuthMapperTest {
         })
         val oauthMapper = OAuthMapperImpl(oauthConfig)
 
-        val userOps = oauthMapper.mapAccessTokenToUserEntity(
+        val userOps = oauthMapper.mapAccessTokenPayloadToUserEntity(
             JWT.create()
                 .withSubject("user-ops")
                 .withClaim("roles", listOf("Ops", "Manager"))
                 .sign(testAlgorithm)
         )
-        val userDev = oauthMapper.mapAccessTokenToUserEntity(
+        val userDev = oauthMapper.mapAccessTokenPayloadToUserEntity(
             JWT.create()
                 .withSubject("user-dev")
                 .withClaim("roles", listOf("QA", "Dev"))
@@ -100,7 +100,7 @@ class OAuthMapperTest {
     }
 
     @Test
-    fun `if roles cannot be matched, mapAccessTokenToUserEntity must return undefined role`() {
+    fun `if roles cannot be matched, mapAccessTokenPayloadToUserEntity must return undefined role`() {
         val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
             put("drill.auth.oauth2.roleMapping.user", "Dev")
             put("drill.auth.oauth2.roleMapping.admin", "Ops")
@@ -108,7 +108,7 @@ class OAuthMapperTest {
         })
         val oauthMapper = OAuthMapperImpl(oauthConfig)
 
-        val userEntity = oauthMapper.mapAccessTokenToUserEntity(
+        val userEntity = oauthMapper.mapAccessTokenPayloadToUserEntity(
             JWT.create()
                 .withSubject("some-username")
                 .withClaim("roles", listOf("QA", "Analyst"))
@@ -119,13 +119,13 @@ class OAuthMapperTest {
     }
 
     @Test
-    fun `if token username mapping is not specified, mapAccessTokenToUserEntity must use default username mapping`() {
+    fun `if token username mapping is not specified, mapAccessTokenPayloadToUserEntity must use default username mapping`() {
         val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
             // no username mapping, default value is "sub"
         })
         val oauthMapper = OAuthMapperImpl(oauthConfig)
 
-        val userEntity = oauthMapper.mapAccessTokenToUserEntity(
+        val userEntity = oauthMapper.mapAccessTokenPayloadToUserEntity(
             JWT.create()
                 .withSubject("some-username")  //this is claim "sub"
                 .sign(testAlgorithm)
@@ -151,13 +151,13 @@ class OAuthMapperTest {
     }
 
     @Test
-    fun `if token roles mapping is not specified, mapAccessTokenToUserEntity must return undefined role`() {
+    fun `if token roles mapping is not specified, mapAccessTokenPayloadToUserEntity must return undefined role`() {
         val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
             // no roles mapping, no default value
         })
         val oauthMapper = OAuthMapperImpl(oauthConfig)
 
-        val userEntity = oauthMapper.mapAccessTokenToUserEntity(
+        val userEntity = oauthMapper.mapAccessTokenPayloadToUserEntity(
             JWT.create()
                 .withSubject("some-username")
                 .withClaim("roles", listOf("user"))
@@ -206,14 +206,14 @@ class OAuthMapperTest {
     }
 
     @Test
-    fun `given not matchable username token mapping config, mapAccessTokenToUserEntity must fail`() {
+    fun `given not matchable username token mapping config, mapAccessTokenPayloadToUserEntity must fail`() {
         val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
             put("drill.auth.oauth2.tokenMapping.username", "username")
         })
         val oauthMapper = OAuthMapperImpl(oauthConfig)
 
         assertThrows<OAuthUnauthorizedException> {
-            oauthMapper.mapAccessTokenToUserEntity(
+            oauthMapper.mapAccessTokenPayloadToUserEntity(
                 JWT.create()
                     .withClaim("login", "some-username")
                     .sign(testAlgorithm)

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthMapperTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthMapperTest.kt
@@ -195,7 +195,7 @@ class OAuthMapperTest {
     }
 
     @Test
-    fun `given not matchable username token mapping config, mapAccessTokenPayloadToUserEntity must fail`() {
+    fun `if token mapping username value is not present in token content, mapAccessTokenPayloadToUserEntity must fail`() {
         val oauthMapper = OAuthMapperImpl(OAuthConfig(MapApplicationConfig().apply {
             put("drill.auth.oauth2.tokenMapping.username", "username")
         }))

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthMapperTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthMapperTest.kt
@@ -37,11 +37,10 @@ class OAuthMapperTest {
 
     @Test
     fun `given token mapping config, mapAccessTokenPayloadToUserEntity must map access token data to user entity`() {
-        val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
+        val oauthMapper = OAuthMapperImpl(OAuthConfig(MapApplicationConfig().apply {
             put("drill.auth.oauth2.tokenMapping.username", "user_name")
             put("drill.auth.oauth2.tokenMapping.roles", "realm_roles")
-        })
-        val oauthMapper = OAuthMapperImpl(oauthConfig)
+        }))
 
         val userEntity = oauthMapper.mapAccessTokenPayloadToUserEntity(
             JWT.create()
@@ -55,11 +54,10 @@ class OAuthMapperTest {
 
     @Test
     fun `given userinfo mapping config, mapUserInfoToUserEntity must map user-info json response to user entity`() {
-        val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
+        val oauthMapper = OAuthMapperImpl(OAuthConfig(MapApplicationConfig().apply {
             put("drill.auth.oauth2.userInfoMapping.username", "user_name")
             put("drill.auth.oauth2.userInfoMapping.roles", "authorities")
-        })
-        val oauthMapper = OAuthMapperImpl(oauthConfig)
+        }))
 
         val userEntity = oauthMapper.mapUserInfoToUserEntity(
             """
@@ -75,12 +73,11 @@ class OAuthMapperTest {
 
     @Test
     fun `given role mapping config, mapAccessTokenPayloadToUserEntity must map roles from access token to Drill4J roles`() {
-        val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
+        val oauthMapper = OAuthMapperImpl(OAuthConfig(MapApplicationConfig().apply {
             put("drill.auth.oauth2.roleMapping.user", "Dev")
             put("drill.auth.oauth2.roleMapping.admin", "Ops")
             put("drill.auth.oauth2.tokenMapping.roles", "roles")
-        })
-        val oauthMapper = OAuthMapperImpl(oauthConfig)
+        }))
 
         val userOps = oauthMapper.mapAccessTokenPayloadToUserEntity(
             JWT.create()
@@ -101,12 +98,11 @@ class OAuthMapperTest {
 
     @Test
     fun `if roles cannot be matched, mapAccessTokenPayloadToUserEntity must return undefined role`() {
-        val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
+        val oauthMapper = OAuthMapperImpl(OAuthConfig(MapApplicationConfig().apply {
             put("drill.auth.oauth2.roleMapping.user", "Dev")
             put("drill.auth.oauth2.roleMapping.admin", "Ops")
             put("drill.auth.oauth2.tokenMapping.roles", "roles")
-        })
-        val oauthMapper = OAuthMapperImpl(oauthConfig)
+        }))
 
         val userEntity = oauthMapper.mapAccessTokenPayloadToUserEntity(
             JWT.create()
@@ -120,10 +116,9 @@ class OAuthMapperTest {
 
     @Test
     fun `if token username mapping is not specified, mapAccessTokenPayloadToUserEntity must use default username mapping`() {
-        val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
+        val oauthMapper = OAuthMapperImpl(OAuthConfig(MapApplicationConfig().apply {
             // no username mapping, default value is "sub"
-        })
-        val oauthMapper = OAuthMapperImpl(oauthConfig)
+        }))
 
         val userEntity = oauthMapper.mapAccessTokenPayloadToUserEntity(
             JWT.create()
@@ -135,10 +130,9 @@ class OAuthMapperTest {
 
     @Test
     fun `if userinfo username mapping is not specified, mapUserInfoToUserEntity must use default username mapping`() {
-        val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
+        val oauthMapper = OAuthMapperImpl(OAuthConfig(MapApplicationConfig().apply {
             // no username mapping, default value is "username"
-        })
-        val oauthMapper = OAuthMapperImpl(oauthConfig)
+        }))
 
         val userEntity = oauthMapper.mapUserInfoToUserEntity(
             """
@@ -152,10 +146,9 @@ class OAuthMapperTest {
 
     @Test
     fun `if token roles mapping is not specified, mapAccessTokenPayloadToUserEntity must return undefined role`() {
-        val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
+        val oauthMapper = OAuthMapperImpl(OAuthConfig(MapApplicationConfig().apply {
             // no roles mapping, no default value
-        })
-        val oauthMapper = OAuthMapperImpl(oauthConfig)
+        }))
 
         val userEntity = oauthMapper.mapAccessTokenPayloadToUserEntity(
             JWT.create()
@@ -168,10 +161,9 @@ class OAuthMapperTest {
 
     @Test
     fun `if userinfo roles mapping is not specified, mapUserInfoToUserEntity must return undefined role`() {
-        val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
+        val oauthMapper = OAuthMapperImpl(OAuthConfig(MapApplicationConfig().apply {
             // no roles mapping, no default value
-        })
-        val oauthMapper = OAuthMapperImpl(oauthConfig)
+        }))
 
         val userEntity = oauthMapper.mapUserInfoToUserEntity(
             """
@@ -207,10 +199,9 @@ class OAuthMapperTest {
 
     @Test
     fun `given not matchable username token mapping config, mapAccessTokenPayloadToUserEntity must fail`() {
-        val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
+        val oauthMapper = OAuthMapperImpl(OAuthConfig(MapApplicationConfig().apply {
             put("drill.auth.oauth2.tokenMapping.username", "username")
-        })
-        val oauthMapper = OAuthMapperImpl(oauthConfig)
+        }))
 
         assertThrows<OAuthUnauthorizedException> {
             oauthMapper.mapAccessTokenPayloadToUserEntity(
@@ -223,10 +214,9 @@ class OAuthMapperTest {
 
     @Test
     fun `given not matchable username userinfo mapping config, mapUserInfoToUserEntity must fail`() {
-        val oauthConfig = OAuthConfig(MapApplicationConfig().apply {
+        val oauthMapper = OAuthMapperImpl(OAuthConfig(MapApplicationConfig().apply {
             put("drill.auth.oauth2.userInfoMapping.username", "username")
-        })
-        val oauthMapper = OAuthMapperImpl(oauthConfig)
+        }))
 
         assertThrows<OAuthUnauthorizedException> {
             oauthMapper.mapUserInfoToUserEntity(

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthMapperTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthMapperTest.kt
@@ -174,8 +174,8 @@ class OAuthMapperTest {
     }
 
     @Test
-    fun `mergeUserEntities must override Database fields with not null fields from OAuth2`() {
-        val mergedUserEntity = oauthMapper.mergeUserEntities(
+    fun `updateDatabaseUserEntity must override Database fields with not null fields from OAuth2`() {
+        val mergedUserEntity = oauthMapper.updateDatabaseUserEntity(
             userFromDatabase = UserEntity(username = testUsername, role = Role.USER.name, id = 123),
             userFromOAuth = UserEntity(username = testUsername, role = Role.ADMIN.name)
         )
@@ -185,8 +185,8 @@ class OAuthMapperTest {
     }
 
     @Test
-    fun `given undefined role from OAuth2, mergeUserEntities return user entity with role from Database`() {
-        val mergedUserEntity = oauthMapper.mergeUserEntities(
+    fun `given undefined role from OAuth2, updateDatabaseUserEntity return user entity with role from Database`() {
+        val mergedUserEntity = oauthMapper.updateDatabaseUserEntity(
             userFromDatabase = UserEntity(username = testUsername, role = Role.USER.name),
             userFromOAuth = UserEntity(username = testUsername, role = Role.UNDEFINED.name)
         )

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthModuleTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthModuleTest.kt
@@ -55,8 +55,6 @@ class OAuthModuleTest {
     private val testDrillHost = "example.com"
     private val testClientId = "test-client"
     private val testClientSecret = "test-secret"
-    private val keyPair = generateRSAKeyPair()
-    private val rsa256 = Algorithm.RSA256(keyPair.public as RSAPublicKey, keyPair.private as RSAPrivateKey)
 
     @Mock
     lateinit var mockOAuthService: OAuthService
@@ -134,16 +132,11 @@ class OAuthModuleTest {
         val testIssuer = "test-issuer"
         val testAuthenticationCode = "test-code"
         val testState = "test-state"
-        val testAccessToken = JWT.create()
-            .withClaim("preferred_username", testUsername)
-            .withClaim("realm_access", mapOf("roles" to listOf("user")))  //TODO remove after adding claim mapping tests
-            .sign(rsa256)
 
         withTestApplication({
             environment {
                 put("drill.auth.oauth2.authorizeUrl", "http://$testOAuthServerHost/authorizeUrl")
                 put("drill.auth.oauth2.accessTokenUrl", "http://$testOAuthServerHost/accessTokenUrl")
-                put("drill.auth.oauth2.userInfoUrl", "http://$testOAuthServerHost/userInfoUrl")
                 put("drill.auth.oauth2.clientId", testClientId)
                 put("drill.auth.oauth2.clientSecret", testClientSecret)
                 put("drill.auth.jwt.issuer", testIssuer)
@@ -163,7 +156,7 @@ class OAuthModuleTest {
                         respondOk(
                             """
                             {
-                              "access_token":"$testAccessToken",                                                            
+                              "access_token":"test-access-token",                                                            
                               "refresh_token":"test-refresh-token"                              
                             }
                             """.trimIndent()
@@ -253,12 +246,6 @@ class OAuthModuleTest {
                 assertEquals(HttpStatusCode.Unauthorized, response.status())
             }
         }
-    }
-
-    private fun generateRSAKeyPair(): KeyPair {
-        val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
-        keyPairGenerator.initialize(2048)
-        return keyPairGenerator.generateKeyPair()
     }
 
     private fun DI.MainBuilder.mockHttpClient(tag: String, vararg requestHandlers: MockHttpRequest) {

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthServiceTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthServiceTest.kt
@@ -61,7 +61,7 @@ class OAuthServiceTest {
             val testAccessToken = "test-access-token"
             val testUserFromOAuth = UserEntity(username = testUsername, role = Role.UNDEFINED.name)
             val oauthService = OAuthServiceImpl(mockHttpClient(), mockConfig, userRepository, oauthMapper)
-            whenever(oauthMapper.mapAccessTokenToUserEntity(testAccessToken)).thenReturn(testUserFromOAuth)
+            whenever(oauthMapper.mapAccessTokenPayloadToUserEntity(testAccessToken)).thenReturn(testUserFromOAuth)
             whenever(userRepository.findByUsername(testUsername)).thenReturn(null)
             whenever(userRepository.create(any())).thenAnswer(CopyUserWithID)
 
@@ -78,7 +78,7 @@ class OAuthServiceTest {
             val testUserFromDatabase = UserEntity(id = 123, username = testUsername, role = Role.USER.name)
             val testUserMustUpdate = UserEntity(id = 123, username = testUsername, role = Role.USER.name)
             val oauthService = OAuthServiceImpl(mockHttpClient(), mockConfig, userRepository, oauthMapper)
-            whenever(oauthMapper.mapAccessTokenToUserEntity(testAccessToken)).thenReturn(testUserFromOAuth)
+            whenever(oauthMapper.mapAccessTokenPayloadToUserEntity(testAccessToken)).thenReturn(testUserFromOAuth)
             whenever(userRepository.findByUsername(testUsername)).thenReturn(testUserFromDatabase)
             whenever(oauthMapper.mergeUserEntities(any(), any())).thenReturn(testUserMustUpdate)
 
@@ -93,7 +93,7 @@ class OAuthServiceTest {
             val testAccessToken = "test-access-token"
             val testUserFromOAuth = UserEntity(username = testUsername, role = Role.USER.name)
             val oauthService = OAuthServiceImpl(mockHttpClient(), mockConfig, userRepository, oauthMapper)
-            whenever(oauthMapper.mapAccessTokenToUserEntity(testAccessToken)).thenReturn(testUserFromOAuth)
+            whenever(oauthMapper.mapAccessTokenPayloadToUserEntity(testAccessToken)).thenReturn(testUserFromOAuth)
             whenever(userRepository.findByUsername(testUsername)).thenReturn(
                 UserEntity(
                     id = 123,
@@ -133,14 +133,14 @@ class OAuthServiceTest {
             val testRole = Role.USER
             val testAccessToken = "test-access-token"
             val oauthService = OAuthServiceImpl(mockHttpClient(), mockConfig, userRepository, oauthMapper)
-            whenever(oauthMapper.mapAccessTokenToUserEntity(testAccessToken)).thenReturn(
+            whenever(oauthMapper.mapAccessTokenPayloadToUserEntity(testAccessToken)).thenReturn(
                 UserEntity(username = testUsername, role = testRole.name)
             )
             whenever(userRepository.findByUsername(testUsername)).thenReturn(null)
             whenever(userRepository.create(any())).thenAnswer(CopyUserWithID)
 
             val userInfo = oauthService.signInThroughOAuth(withPrincipal(testAccessToken))
-            verify(oauthMapper).mapAccessTokenToUserEntity(testAccessToken)
+            verify(oauthMapper).mapAccessTokenPayloadToUserEntity(testAccessToken)
             assertEquals(testUsername, userInfo.username)
             assertEquals(testRole, userInfo.role)
         }
@@ -183,7 +183,7 @@ class OAuthServiceTest {
             val mergedRole = Role.UNDEFINED
 
             val oauthService = OAuthServiceImpl(mockHttpClient(), mockConfig, userRepository, oauthMapper)
-            whenever(oauthMapper.mapAccessTokenToUserEntity(testAccessToken)).thenReturn(testUserFromOAuth)
+            whenever(oauthMapper.mapAccessTokenPayloadToUserEntity(testAccessToken)).thenReturn(testUserFromOAuth)
             whenever(userRepository.findByUsername(testUsername)).thenReturn(testUserFromDatabase)
             whenever(oauthMapper.mergeUserEntities(testUserFromDatabase, testUserFromOAuth)).thenReturn(
                 UserEntity(id = testUserId, username = testUsername, role = mergedRole.name)

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthServiceTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthServiceTest.kt
@@ -80,7 +80,7 @@ class OAuthServiceTest {
             val oauthService = OAuthServiceImpl(mockHttpClient(), mockConfig, userRepository, oauthMapper)
             whenever(oauthMapper.mapAccessTokenPayloadToUserEntity(testAccessToken)).thenReturn(testUserFromOAuth)
             whenever(userRepository.findByUsername(testUsername)).thenReturn(testUserFromDatabase)
-            whenever(oauthMapper.mergeUserEntities(any(), any())).thenReturn(testUserMustUpdate)
+            whenever(oauthMapper.updateDatabaseUserEntity(any(), any())).thenReturn(testUserMustUpdate)
 
             oauthService.signInThroughOAuth(withPrincipal(testAccessToken))
             verify(userRepository).update(testUserMustUpdate)
@@ -185,12 +185,12 @@ class OAuthServiceTest {
             val oauthService = OAuthServiceImpl(mockHttpClient(), mockConfig, userRepository, oauthMapper)
             whenever(oauthMapper.mapAccessTokenPayloadToUserEntity(testAccessToken)).thenReturn(testUserFromOAuth)
             whenever(userRepository.findByUsername(testUsername)).thenReturn(testUserFromDatabase)
-            whenever(oauthMapper.mergeUserEntities(testUserFromDatabase, testUserFromOAuth)).thenReturn(
+            whenever(oauthMapper.updateDatabaseUserEntity(testUserFromDatabase, testUserFromOAuth)).thenReturn(
                 UserEntity(id = testUserId, username = testUsername, role = mergedRole.name)
             )
 
             val userInfo = oauthService.signInThroughOAuth(withPrincipal(testAccessToken))
-            verify(oauthMapper).mergeUserEntities(testUserFromDatabase, testUserFromOAuth)
+            verify(oauthMapper).updateDatabaseUserEntity(testUserFromDatabase, testUserFromOAuth)
             verify(userRepository).update(UserEntity(id = testUserId, username = testUsername, role = mergedRole.name))
             assertEquals(testUsername, userInfo.username)
             assertEquals(mergedRole, userInfo.role)

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthServiceTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthServiceTest.kt
@@ -51,141 +51,137 @@ class OAuthServiceTest {
     }
 
     @Test
-    fun `given user that is authenticated through the OAuth2 first time, signInThroughOAuth must create new user`() =
+    fun `given user, authenticating with OAuth2 first time, signInThroughOAuth must create user entity with data from OAuth2`(): Unit =
         runBlocking {
             val testUsername = "some-username"
             val testAccessToken = JWT.create()
                 .withSubject(testUsername)
                 .sign(testAlgorithm)
-
             val oauthService = OAuthServiceImpl(mockHttpClient(), OAuthConfig(MapApplicationConfig()), userRepository)
             whenever(userRepository.findByUsername(testUsername)).thenReturn(null)
             whenever(userRepository.create(any())).thenReturn(123)
 
-            val userInfo = oauthService.signInThroughOAuth(withPrincipal(testAccessToken))
+            oauthService.signInThroughOAuth(withPrincipal(testAccessToken))
             verify(userRepository).create(UserEntity(username = testUsername, role = Role.UNDEFINED.name))
-            assertEquals(testUsername, userInfo.username)
         }
 
     @Test
-    fun `given user that is authenticated through OAuth2 again, signInThroughOAuth must update user`() = runBlocking {
-        val testUsername = "some-username"
-        val testAccessToken = JWT.create()
-            .withSubject(testUsername)
-            .sign(testAlgorithm)
-
-        val oauthService = OAuthServiceImpl(mockHttpClient(), OAuthConfig(MapApplicationConfig()), userRepository)
-        whenever(userRepository.findByUsername(testUsername)).thenReturn(
-            UserEntity(id = 123, username = testUsername, role = Role.USER.name)
-        )
-
-        val userInfo = oauthService.signInThroughOAuth(withPrincipal(testAccessToken))
-        verify(userRepository).update(UserEntity(id = 123, username = testUsername, role = Role.USER.name))
-        assertEquals(testUsername, userInfo.username)
-    }
-
-    @Test
-    fun `given blocked OAuth2 principal, signInThroughOAuth must fail`(): Unit = runBlocking {
-        val testUsername = "some-username"
-        val testAccessToken = JWT.create()
-            .withSubject(testUsername)
-            .sign(testAlgorithm)
-
-        val oauthService = OAuthServiceImpl(mockHttpClient(), OAuthConfig(MapApplicationConfig()), userRepository)
-        whenever(userRepository.findByUsername(testUsername)).thenReturn(
-            UserEntity(
-                id = 123,
-                username = testUsername,
-                role = Role.USER.name,
-                blocked = true
+    fun `given existing user, authenticating with OAuth2, signInThroughOAuth must update user entity with data from OAuth2`() =
+        runBlocking {
+            val testUsername = "some-username"
+            val testAccessToken = JWT.create()
+                .withSubject(testUsername)
+                .sign(testAlgorithm)
+            val oauthService = OAuthServiceImpl(mockHttpClient(), OAuthConfig(MapApplicationConfig()), userRepository)
+            whenever(userRepository.findByUsername(testUsername)).thenReturn(
+                UserEntity(id = 123, username = testUsername, role = Role.USER.name)
             )
-        )
 
-        assertThrows<OAuthAccessDeniedException> {
             oauthService.signInThroughOAuth(withPrincipal(testAccessToken))
+            verify(userRepository).update(UserEntity(id = 123, username = testUsername, role = Role.USER.name))
         }
-    }
 
     @Test
-    fun `if userinfo request fails, signInThroughOAuth must fail`(): Unit = runBlocking {
-        val testAccessToken = "invalid-token"
+    fun `given blocked user, authenticating with OAuth2, signInThroughOAuth must fail`(): Unit =
+        runBlocking {
+            val testUsername = "some-username"
+            val testAccessToken = JWT.create()
+                .withSubject(testUsername)
+                .sign(testAlgorithm)
+            val oauthService = OAuthServiceImpl(mockHttpClient(), OAuthConfig(MapApplicationConfig()), userRepository)
+            whenever(userRepository.findByUsername(testUsername)).thenReturn(
+                UserEntity(
+                    id = 123,
+                    username = testUsername,
+                    role = Role.USER.name,
+                    blocked = true
+                )
+            )
 
-        val config = MapApplicationConfig().apply {
-            put("drill.auth.oauth2.userInfoUrl", "http://some-oauth-server.com/userInfoUrl")
-        }
-        val httpClient = mockHttpClient(
-            "/userInfoUrl" shouldRespond {
-                respondError(HttpStatusCode.Unauthorized, "Invalid token")
+            assertThrows<OAuthAccessDeniedException> {
+                oauthService.signInThroughOAuth(withPrincipal(testAccessToken))
             }
-        )
-        val oauthService = OAuthServiceImpl(httpClient, OAuthConfig(config), userRepository)
-
-        assertThrows<OAuthUnauthorizedException> {
-            oauthService.signInThroughOAuth(withPrincipal(testAccessToken))
         }
-    }
 
     @Test
-    fun `access token username and role mapping`(): Unit = runBlocking {
-        val testUsername = "some-username"
-        val testAccessToken = JWT.create()
-            .withClaim("login", testUsername)
-            .withClaim("authorities", listOf("one-role", "Dev", "another-role"))
-            .sign(testAlgorithm)
+    fun `if user-info request fails, signInThroughOAuth must fail`(): Unit =
+        runBlocking {
+            val config = MapApplicationConfig().apply {
+                put("drill.auth.oauth2.userInfoUrl", "http://some-oauth-server.com/userInfoUrl")
+            }
+            val httpClient = mockHttpClient(
+                "/userInfoUrl" shouldRespond {
+                    respondError(HttpStatusCode.Unauthorized, "Invalid token")
+                }
+            )
+            val oauthService = OAuthServiceImpl(httpClient, OAuthConfig(config), userRepository)
 
-        val config = MapApplicationConfig().apply {
-            put("drill.auth.oauth2.tokenMapping.username", "login")
-            put("drill.auth.oauth2.tokenMapping.roles", "authorities")
-            put("drill.auth.oauth2.roleMapping.user", "DEV")
-            put("drill.auth.oauth2.roleMapping.admin", "OPS")
+            assertThrows<OAuthUnauthorizedException> {
+                oauthService.signInThroughOAuth(withPrincipal("invalid-token"))
+            }
         }
-        val oauthService = OAuthServiceImpl(mockHttpClient(), OAuthConfig(config), userRepository)
-        whenever(userRepository.findByUsername(testUsername))
-            .thenReturn(UserEntity(id = 123, username = testUsername, role = Role.UNDEFINED.name))
-        whenever(userRepository.update(any())).thenReturn(Unit)
-
-        val userInfo = oauthService.signInThroughOAuth(withPrincipal(testAccessToken))
-        verify(userRepository).update(UserEntity(id = 123, username = testUsername, role = Role.USER.name))
-        assertEquals(testUsername, userInfo.username)
-        assertEquals(Role.USER, userInfo.role)
-    }
 
     @Test
-    fun `user info username and role mapping`(): Unit = runBlocking {
-        val testUsername = "some-username"
+    fun `signInThroughOAuth must extract user data from access token`(): Unit =
+        runBlocking {
+            val testUsername = "some-username"
+            val testAccessToken = JWT.create()
+                .withClaim("login", testUsername)
+                .withClaim("authorities", listOf("one-role", "Dev", "another-role"))
+                .sign(testAlgorithm)
 
-        val config = MapApplicationConfig().apply {
-            put("drill.auth.oauth2.userInfoUrl", "http://some-oauth-server.com/userInfoUrl")
-            put("drill.auth.oauth2.userInfoMapping.username", "user_name")
-            put("drill.auth.oauth2.userInfoMapping.roles", "realm_roles")
-            put("drill.auth.oauth2.roleMapping.user", "DEV")
-            put("drill.auth.oauth2.roleMapping.admin", "OPS")
+            val config = MapApplicationConfig().apply {
+                put("drill.auth.oauth2.tokenMapping.username", "login")
+                put("drill.auth.oauth2.tokenMapping.roles", "authorities")
+                put("drill.auth.oauth2.roleMapping.user", "DEV")
+                put("drill.auth.oauth2.roleMapping.admin", "OPS")
+            }
+            val oauthService = OAuthServiceImpl(mockHttpClient(), OAuthConfig(config), userRepository)
+            whenever(userRepository.findByUsername(testUsername))
+                .thenReturn(UserEntity(id = 123, username = testUsername, role = Role.UNDEFINED.name))
+            whenever(userRepository.update(any())).thenReturn(Unit)
+
+            val userInfo = oauthService.signInThroughOAuth(withPrincipal(testAccessToken))
+            assertEquals(testUsername, userInfo.username)
+            assertEquals(Role.USER, userInfo.role)
         }
-        val httpClient = mockHttpClient(
-            "/userInfoUrl" shouldRespond {
-                respondOk(
-                    """
+
+    @Test
+    fun `signInThroughOAuth must extract user data from user-info response`(): Unit =
+        runBlocking {
+            val testUsername = "some-username"
+
+            val config = MapApplicationConfig().apply {
+                put("drill.auth.oauth2.userInfoUrl", "http://some-oauth-server.com/userInfoUrl")
+                put("drill.auth.oauth2.userInfoMapping.username", "user_name")
+                put("drill.auth.oauth2.userInfoMapping.roles", "realm_roles")
+                put("drill.auth.oauth2.roleMapping.user", "DEV")
+                put("drill.auth.oauth2.roleMapping.admin", "OPS")
+            }
+            val httpClient = mockHttpClient(
+                "/userInfoUrl" shouldRespond {
+                    respondOk(
+                        """
                     {                              
                       "user_name":"$testUsername",
                       "realm_roles":["one-role", "Dev", "another-role"]                             
                     }     
                     """.trimIndent()
-                )
-            }
-        )
-        val oauthService = OAuthServiceImpl(httpClient, OAuthConfig(config), userRepository)
-        whenever(
-            userRepository.findByUsername(testUsername)
-        ).thenReturn(
-            UserEntity(id = 123, username = testUsername, role = Role.UNDEFINED.name)
-        )
-        whenever(userRepository.update(any())).thenReturn(Unit)
+                    )
+                }
+            )
+            val oauthService = OAuthServiceImpl(httpClient, OAuthConfig(config), userRepository)
+            whenever(
+                userRepository.findByUsername(testUsername)
+            ).thenReturn(
+                UserEntity(id = 123, username = testUsername, role = Role.UNDEFINED.name)
+            )
+            whenever(userRepository.update(any())).thenReturn(Unit)
 
-        val userInfo = oauthService.signInThroughOAuth(withPrincipal("test-access-token"))
-        verify(userRepository).update(UserEntity(id = 123, username = testUsername, role = Role.USER.name))
-        assertEquals(testUsername, userInfo.username)
-        assertEquals(Role.USER, userInfo.role)
-    }
+            val userInfo = oauthService.signInThroughOAuth(withPrincipal("test-access-token"))
+            assertEquals(testUsername, userInfo.username)
+            assertEquals(Role.USER, userInfo.role)
+        }
 
     private fun withPrincipal(testAccessToken: String) = OAuthAccessTokenResponse.OAuth2(
         accessToken = testAccessToken,
@@ -193,22 +189,6 @@ class OAuthServiceTest {
         expiresIn = 3600,
         refreshToken = null
     )
-
-    private fun assertTokenAndRespondSuccess(
-        testAccessToken: String,
-        testUsername: String,
-        testRole: String
-    ): ResponseHandler = { request ->
-        assertEquals("Bearer $testAccessToken", request.headers[HttpHeaders.Authorization])
-        respondOk(
-            """
-                    {                              
-                      "username":"$testUsername",
-                      "roles":["$testRole"]                             
-                    }     
-                    """.trimIndent()
-        )
-    }
 
 }
 

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthServiceTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/OAuthServiceTest.kt
@@ -15,14 +15,13 @@
  */
 package com.epam.drill.admin.auth
 
-import com.auth0.jwt.JWT
-import com.auth0.jwt.algorithms.Algorithm
 import com.epam.drill.admin.auth.config.OAuthAccessDeniedException
 import com.epam.drill.admin.auth.config.OAuthConfig
 import com.epam.drill.admin.auth.config.OAuthUnauthorizedException
 import com.epam.drill.admin.auth.entity.UserEntity
 import com.epam.drill.admin.auth.principal.Role
 import com.epam.drill.admin.auth.repository.UserRepository
+import com.epam.drill.admin.auth.service.OAuthMapper
 import com.epam.drill.admin.auth.service.impl.OAuthServiceImpl
 import io.ktor.auth.*
 import io.ktor.client.engine.mock.*
@@ -32,9 +31,11 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
+import org.mockito.invocation.InvocationOnMock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.mockito.stubbing.Answer
 import kotlin.test.*
 
 /**
@@ -43,7 +44,10 @@ import kotlin.test.*
 class OAuthServiceTest {
     @Mock
     lateinit var userRepository: UserRepository
-    private val testAlgorithm = Algorithm.HMAC512("secret")
+    @Mock
+    lateinit var oauthMapper: OAuthMapper
+
+    private val mockConfig = OAuthConfig(MapApplicationConfig())
 
     @BeforeTest
     fun setup() {
@@ -54,41 +58,42 @@ class OAuthServiceTest {
     fun `given user, authenticating with OAuth2 first time, signInThroughOAuth must create user entity with data from OAuth2`(): Unit =
         runBlocking {
             val testUsername = "some-username"
-            val testAccessToken = JWT.create()
-                .withSubject(testUsername)
-                .sign(testAlgorithm)
-            val oauthService = OAuthServiceImpl(mockHttpClient(), OAuthConfig(MapApplicationConfig()), userRepository)
+            val testAccessToken = "test-access-token"
+            val testUserFromOAuth = UserEntity(username = testUsername, role = Role.UNDEFINED.name)
+            val oauthService = OAuthServiceImpl(mockHttpClient(), mockConfig, userRepository, oauthMapper)
+            whenever(oauthMapper.mapAccessTokenToUserEntity(testAccessToken)).thenReturn(testUserFromOAuth)
             whenever(userRepository.findByUsername(testUsername)).thenReturn(null)
-            whenever(userRepository.create(any())).thenReturn(UserEntity(id = 123, username = testUsername, role = Role.USER.name))
+            whenever(userRepository.create(any())).thenAnswer(CopyUserWithID)
 
             oauthService.signInThroughOAuth(withPrincipal(testAccessToken))
-            verify(userRepository).create(UserEntity(username = testUsername, role = Role.UNDEFINED.name))
+            verify(userRepository).create(testUserFromOAuth)
         }
 
     @Test
     fun `given existing user, authenticating with OAuth2, signInThroughOAuth must update user entity with data from OAuth2`() =
         runBlocking {
             val testUsername = "some-username"
-            val testAccessToken = JWT.create()
-                .withSubject(testUsername)
-                .sign(testAlgorithm)
-            val oauthService = OAuthServiceImpl(mockHttpClient(), OAuthConfig(MapApplicationConfig()), userRepository)
-            whenever(userRepository.findByUsername(testUsername)).thenReturn(
-                UserEntity(id = 123, username = testUsername, role = Role.USER.name)
-            )
+            val testAccessToken = "test-access-token"
+            val testUserFromOAuth = UserEntity(username = testUsername, role = Role.UNDEFINED.name)
+            val testUserFromDatabase = UserEntity(id = 123, username = testUsername, role = Role.USER.name)
+            val testUserMustUpdate = UserEntity(id = 123, username = testUsername, role = Role.USER.name)
+            val oauthService = OAuthServiceImpl(mockHttpClient(), mockConfig, userRepository, oauthMapper)
+            whenever(oauthMapper.mapAccessTokenToUserEntity(testAccessToken)).thenReturn(testUserFromOAuth)
+            whenever(userRepository.findByUsername(testUsername)).thenReturn(testUserFromDatabase)
+            whenever(oauthMapper.mergeUserEntities(any(), any())).thenReturn(testUserMustUpdate)
 
             oauthService.signInThroughOAuth(withPrincipal(testAccessToken))
-            verify(userRepository).update(UserEntity(id = 123, username = testUsername, role = Role.USER.name))
+            verify(userRepository).update(testUserMustUpdate)
         }
 
     @Test
     fun `given blocked user, authenticating with OAuth2, signInThroughOAuth must fail`(): Unit =
         runBlocking {
             val testUsername = "some-username"
-            val testAccessToken = JWT.create()
-                .withSubject(testUsername)
-                .sign(testAlgorithm)
-            val oauthService = OAuthServiceImpl(mockHttpClient(), OAuthConfig(MapApplicationConfig()), userRepository)
+            val testAccessToken = "test-access-token"
+            val testUserFromOAuth = UserEntity(username = testUsername, role = Role.USER.name)
+            val oauthService = OAuthServiceImpl(mockHttpClient(), mockConfig, userRepository, oauthMapper)
+            whenever(oauthMapper.mapAccessTokenToUserEntity(testAccessToken)).thenReturn(testUserFromOAuth)
             whenever(userRepository.findByUsername(testUsername)).thenReturn(
                 UserEntity(
                     id = 123,
@@ -114,7 +119,7 @@ class OAuthServiceTest {
                     respondError(HttpStatusCode.Unauthorized, "Invalid token")
                 }
             )
-            val oauthService = OAuthServiceImpl(httpClient, OAuthConfig(config), userRepository)
+            val oauthService = OAuthServiceImpl(httpClient, OAuthConfig(config), userRepository, oauthMapper)
 
             assertThrows<OAuthUnauthorizedException> {
                 oauthService.signInThroughOAuth(withPrincipal("invalid-token"))
@@ -122,65 +127,73 @@ class OAuthServiceTest {
         }
 
     @Test
-    fun `signInThroughOAuth must extract user data from access token`(): Unit =
+    fun `if userInfoUrl is not specified, signInThroughOAuth must extract user data from access token`(): Unit =
         runBlocking {
             val testUsername = "some-username"
-            val testAccessToken = JWT.create()
-                .withClaim("login", testUsername)
-                .withClaim("authorities", listOf("one-role", "Dev", "another-role"))
-                .sign(testAlgorithm)
-
-            val config = MapApplicationConfig().apply {
-                put("drill.auth.oauth2.tokenMapping.username", "login")
-                put("drill.auth.oauth2.tokenMapping.roles", "authorities")
-                put("drill.auth.oauth2.roleMapping.user", "DEV")
-                put("drill.auth.oauth2.roleMapping.admin", "OPS")
-            }
-            val oauthService = OAuthServiceImpl(mockHttpClient(), OAuthConfig(config), userRepository)
-            whenever(userRepository.findByUsername(testUsername))
-                .thenReturn(UserEntity(id = 123, username = testUsername, role = Role.UNDEFINED.name))
-            whenever(userRepository.update(any())).thenReturn(Unit)
+            val testRole = Role.USER
+            val testAccessToken = "test-access-token"
+            val oauthService = OAuthServiceImpl(mockHttpClient(), mockConfig, userRepository, oauthMapper)
+            whenever(oauthMapper.mapAccessTokenToUserEntity(testAccessToken)).thenReturn(
+                UserEntity(username = testUsername, role = testRole.name)
+            )
+            whenever(userRepository.findByUsername(testUsername)).thenReturn(null)
+            whenever(userRepository.create(any())).thenAnswer(CopyUserWithID)
 
             val userInfo = oauthService.signInThroughOAuth(withPrincipal(testAccessToken))
+            verify(oauthMapper).mapAccessTokenToUserEntity(testAccessToken)
             assertEquals(testUsername, userInfo.username)
-            assertEquals(Role.USER, userInfo.role)
+            assertEquals(testRole, userInfo.role)
         }
 
     @Test
-    fun `signInThroughOAuth must extract user data from user-info response`(): Unit =
+    fun `if userInfoUrl is specified, signInThroughOAuth must extract user data from user-info response`(): Unit =
         runBlocking {
             val testUsername = "some-username"
-
+            val testRole = Role.USER
+            val testUserInfoResponse = "some-username-with-role-user"
             val config = MapApplicationConfig().apply {
                 put("drill.auth.oauth2.userInfoUrl", "http://some-oauth-server.com/userInfoUrl")
-                put("drill.auth.oauth2.userInfoMapping.username", "user_name")
-                put("drill.auth.oauth2.userInfoMapping.roles", "realm_roles")
-                put("drill.auth.oauth2.roleMapping.user", "DEV")
-                put("drill.auth.oauth2.roleMapping.admin", "OPS")
             }
             val httpClient = mockHttpClient(
                 "/userInfoUrl" shouldRespond {
-                    respondOk(
-                        """
-                    {                              
-                      "user_name":"$testUsername",
-                      "realm_roles":["one-role", "Dev", "another-role"]                             
-                    }     
-                    """.trimIndent()
-                    )
+                    respondOk(testUserInfoResponse)
                 }
             )
-            val oauthService = OAuthServiceImpl(httpClient, OAuthConfig(config), userRepository)
-            whenever(
-                userRepository.findByUsername(testUsername)
-            ).thenReturn(
-                UserEntity(id = 123, username = testUsername, role = Role.UNDEFINED.name)
+            val oauthService = OAuthServiceImpl(httpClient, OAuthConfig(config), userRepository, oauthMapper)
+            whenever(oauthMapper.mapUserInfoToUserEntity(testUserInfoResponse)).thenReturn(
+                UserEntity(username = testUsername, role = testRole.name)
             )
-            whenever(userRepository.update(any())).thenReturn(Unit)
+            whenever(userRepository.findByUsername(testUsername)).thenReturn(null)
+            whenever(userRepository.create(any())).thenAnswer(CopyUserWithID)
 
             val userInfo = oauthService.signInThroughOAuth(withPrincipal("test-access-token"))
+            verify(oauthMapper).mapUserInfoToUserEntity(testUserInfoResponse)
             assertEquals(testUsername, userInfo.username)
-            assertEquals(Role.USER, userInfo.role)
+            assertEquals(testRole, userInfo.role)
+        }
+
+    @Test
+    fun `signInThroughOAuth must merge existing user data and OAuth2 user data and store it in database`(): Unit =
+        runBlocking {
+            val testUsername = "some-username"
+            val testAccessToken = "test-access-token"
+            val testUserFromOAuth = UserEntity(username = testUsername, role = Role.USER.name)
+            val testUserId = 123
+            val testUserFromDatabase = UserEntity(id = testUserId, username = testUsername, role = Role.ADMIN.name)
+            val mergedRole = Role.UNDEFINED
+
+            val oauthService = OAuthServiceImpl(mockHttpClient(), mockConfig, userRepository, oauthMapper)
+            whenever(oauthMapper.mapAccessTokenToUserEntity(testAccessToken)).thenReturn(testUserFromOAuth)
+            whenever(userRepository.findByUsername(testUsername)).thenReturn(testUserFromDatabase)
+            whenever(oauthMapper.mergeUserEntities(testUserFromDatabase, testUserFromOAuth)).thenReturn(
+                UserEntity(id = testUserId, username = testUsername, role = mergedRole.name)
+            )
+
+            val userInfo = oauthService.signInThroughOAuth(withPrincipal(testAccessToken))
+            verify(oauthMapper).mergeUserEntities(testUserFromDatabase, testUserFromOAuth)
+            verify(userRepository).update(UserEntity(id = testUserId, username = testUsername, role = mergedRole.name))
+            assertEquals(testUsername, userInfo.username)
+            assertEquals(mergedRole, userInfo.role)
         }
 
     private fun withPrincipal(testAccessToken: String) = OAuthAccessTokenResponse.OAuth2(
@@ -189,6 +202,10 @@ class OAuthServiceTest {
         expiresIn = 3600,
         refreshToken = null
     )
+
+    object CopyUserWithID: Answer<UserEntity> {
+        override fun answer(invocation: InvocationOnMock?) = invocation?.getArgument<UserEntity>(0)?.copy(id = 123)
+    }
 
 }
 


### PR DESCRIPTION
Features:
- Configurable mapping between oauth2 access token claims and user attributes (username, roles etc.)
- Configurable mapping between user info response and user attributes
- Configurable mapping between OAuth2 roles and Drill4J roles
- Calling OAuth2 user-info service is optional
- OAuth2 roles mapping is optional

For discussion:
- I believe that in OAuth2 providers there is more often a list of roles than one role, so in the mapping there are only "roles" mapping and no "role" mapping.
- If userInfoUrl is not specified, the access token is mapped, and vice versa, if userInfoUrl is present, only the user-info response is mapped. Should combine mapping of both?