### PR TITLE
Feature/api keys services implementation epmdj 10739

### DIFF
--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/entity/ApiKeyEntity.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/entity/ApiKeyEntity.kt
@@ -8,5 +8,6 @@ data class ApiKeyEntity(
     val description: String,
     val apiKeyHash: String,
     val expiresAt: LocalDateTime,
-    val createdAt: LocalDateTime
+    val createdAt: LocalDateTime,
+    val user: UserEntity? = null
 )

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/entity/ApiKeyEntity.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/entity/ApiKeyEntity.kt
@@ -4,9 +4,9 @@ import java.time.LocalDateTime
 
 data class ApiKeyEntity(
     val id: Int? = null,
-    val user: UserEntity,
+    val userId: Int,
     val description: String,
     val apiKeyHash: String,
     val expiresAt: LocalDateTime,
-    val createdAt: LocalDateTime? = null
+    val createdAt: LocalDateTime
 )

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/model/ApiKeyModels.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/model/ApiKeyModels.kt
@@ -9,17 +9,25 @@ data class ApiKeyView(
     val id: Int,
     val userId: Int,
     val description: String,
-    val expired: LocalDateTime,
-    val created: LocalDateTime,
+    val expiresAt: LocalDateTime,
+    val createdAt: LocalDateTime,
     val username: String,
-    val role: Role
+    val role: Role,
+)
+
+@Serializable
+data class UserApiKeyView(
+    val id: Int,
+    val description: String,
+    val expiresAt: LocalDateTime,
+    val createdAt: LocalDateTime,
 )
 
 @Serializable
 data class ApiKeyCredentialsView(
     val id: Int,
     val apiKey: String,
-    val expired: LocalDateTime
+    val expiresAt: LocalDateTime
 )
 
 @Serializable

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/repository/ApiKeyRepository.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/repository/ApiKeyRepository.kt
@@ -5,6 +5,6 @@ import com.epam.drill.admin.auth.entity.ApiKeyEntity
 interface ApiKeyRepository {
     suspend fun getAll(): List<ApiKeyEntity>
     suspend fun getAllByUserId(userId: Int): List<ApiKeyEntity>
-    suspend fun delete(id: Int)
+    suspend fun deleteById(id: Int)
     suspend fun create(entity: ApiKeyEntity): ApiKeyEntity
 }

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/repository/ApiKeyRepository.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/repository/ApiKeyRepository.kt
@@ -3,8 +3,8 @@ package com.epam.drill.admin.auth.repository
 import com.epam.drill.admin.auth.entity.ApiKeyEntity
 
 interface ApiKeyRepository {
-    suspend fun getAllApiKeys(): List<ApiKeyEntity>
-    suspend fun getApiKeysByUserId(userId: Int): List<ApiKeyEntity>
-    suspend fun deleteApiKey(id: Int)
-    suspend fun createApiKey(entity: ApiKeyEntity): ApiKeyEntity
+    suspend fun getAll(): List<ApiKeyEntity>
+    suspend fun getAllByUserId(userId: Int): List<ApiKeyEntity>
+    suspend fun delete(id: Int)
+    suspend fun create(entity: ApiKeyEntity): ApiKeyEntity
 }

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/repository/impl/DatabaseApiKeyRepository.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/repository/impl/DatabaseApiKeyRepository.kt
@@ -17,7 +17,7 @@ class DatabaseApiKeyRepository: ApiKeyRepository {
         return ApiKeyTable.select { ApiKeyTable.userId eq userId }.map { it.toEntity() }
     }
 
-    override suspend fun delete(id: Int) {
+    override suspend fun deleteById(id: Int) {
         ApiKeyTable.deleteWhere { ApiKeyTable.id eq id }
     }
 
@@ -32,7 +32,17 @@ private fun ResultRow.toEntity() = ApiKeyEntity(
     description = this[ApiKeyTable.description],
     apiKeyHash = this[ApiKeyTable.apiKeyHash],
     expiresAt = this[ApiKeyTable.expiresAt],
-    createdAt = this[ApiKeyTable.createdAt]
+    createdAt = this[ApiKeyTable.createdAt],
+    user = this.hasValue(UserTable.username).takeIf { it }?.let {
+        UserEntity(
+            id = this[ApiKeyTable.userId],
+            username = this[UserTable.username],
+            passwordHash = this[UserTable.passwordHash],
+            role = this[UserTable.role],
+            blocked = this[UserTable.blocked],
+            registrationDate = this[UserTable.registrationDate]
+        )
+    },
 )
 
 private fun ApiKeyEntity.mapTo(builder: UpdateBuilder<Int>) {

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/repository/impl/DatabaseApiKeyRepository.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/repository/impl/DatabaseApiKeyRepository.kt
@@ -1,0 +1,44 @@
+package com.epam.drill.admin.auth.repository.impl
+
+import com.epam.drill.admin.auth.entity.ApiKeyEntity
+import com.epam.drill.admin.auth.entity.UserEntity
+import com.epam.drill.admin.auth.repository.ApiKeyRepository
+import com.epam.drill.admin.auth.table.ApiKeyTable
+import com.epam.drill.admin.auth.table.UserTable
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.statements.UpdateBuilder
+
+class DatabaseApiKeyRepository: ApiKeyRepository {
+    override suspend fun getAll(): List<ApiKeyEntity> {
+        return (ApiKeyTable innerJoin UserTable).selectAll().map { it.toEntity() }
+    }
+
+    override suspend fun getAllByUserId(userId: Int): List<ApiKeyEntity> {
+        return ApiKeyTable.select { ApiKeyTable.userId eq userId }.map { it.toEntity() }
+    }
+
+    override suspend fun delete(id: Int) {
+        ApiKeyTable.deleteWhere { ApiKeyTable.id eq id }
+    }
+
+    override suspend fun create(entity: ApiKeyEntity): ApiKeyEntity {
+        return ApiKeyTable.insertAndGetId { entity.mapTo(it) }.value.let { entity.copy(id = it) }
+    }
+}
+
+private fun ResultRow.toEntity() = ApiKeyEntity(
+    id = this[ApiKeyTable.id].value,
+    userId = this[ApiKeyTable.userId],
+    description = this[ApiKeyTable.description],
+    apiKeyHash = this[ApiKeyTable.apiKeyHash],
+    expiresAt = this[ApiKeyTable.expiresAt],
+    createdAt = this[ApiKeyTable.createdAt]
+)
+
+private fun ApiKeyEntity.mapTo(builder: UpdateBuilder<Int>) {
+    builder[ApiKeyTable.description] = description
+    builder[ApiKeyTable.apiKeyHash] = apiKeyHash
+    builder[ApiKeyTable.userId] = userId
+    builder[ApiKeyTable.expiresAt] = expiresAt
+    builder[ApiKeyTable.createdAt] = createdAt
+}

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/route/UserApiKeyRoutes.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/route/UserApiKeyRoutes.kt
@@ -14,7 +14,10 @@ import org.kodein.di.instance
 import org.kodein.di.ktor.closestDI
 
 @Location("/user-keys")
-object UserApiKeys
+object UserApiKeys {
+    @Location("/{id}")
+    data class Id(val id: Int)
+}
 
 /**
  * A user API keys routes configuration.
@@ -58,9 +61,10 @@ fun Route.generateUserApiKeyRoute() {
 fun Route.deleteUserApiKeyRoute() {
     val apiKeyService by closestDI().instance<ApiKeyService>()
 
-    delete<UserApiKeys> {
+    delete<UserApiKeys.Id> { params ->
         val principal = call.principal<User>() ?: throw NotAuthenticatedException()
-        apiKeyService.deleteApiKey(principal.id)
+        val apiKeyId = params.id
+        apiKeyService.deleteApiKey(apiKeyId)
         call.ok("API Key successfully deleted.")
     }
 }

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/ApiKeyService.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/ApiKeyService.kt
@@ -3,11 +3,12 @@ package com.epam.drill.admin.auth.service
 import com.epam.drill.admin.auth.model.ApiKeyCredentialsView
 import com.epam.drill.admin.auth.model.ApiKeyView
 import com.epam.drill.admin.auth.model.GenerateApiKeyPayload
+import com.epam.drill.admin.auth.model.UserApiKeyView
 
 interface ApiKeyService {
     suspend fun getAllApiKeys(): List<ApiKeyView>
 
-    suspend fun getApiKeysByUser(userId: Int): List<ApiKeyView>
+    suspend fun getApiKeysByUser(userId: Int): List<UserApiKeyView>
 
     suspend fun deleteApiKey(id: Int)
 

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/ApiKeyServiceImpl.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/ApiKeyServiceImpl.kt
@@ -16,7 +16,8 @@ import java.util.*
 
 class ApiKeyServiceImpl(
     private val repository: ApiKeyRepository,
-    private val passwordService: PasswordService
+    private val passwordService: PasswordService,
+    private val currentDateTimeProvider: () -> LocalDateTime = { LocalDateTime.now() }
 ): ApiKeyService {
     override suspend fun getAllApiKeys(): List<ApiKeyView> {
         return repository.getAll()
@@ -39,8 +40,8 @@ class ApiKeyServiceImpl(
             userId = userId,
             description = payload.description,
             apiKeyHash = apiKeyHash,
-            expiresAt = LocalDateTime.now().plusMonths(payload.expiryPeriod.months.toLong()),
-            createdAt = LocalDateTime.now()
+            expiresAt = currentDateTimeProvider().plusMonths(payload.expiryPeriod.months.toLong()),
+            createdAt = currentDateTimeProvider()
         )
         val entityWithId = repository.create(entity)
         return ApiKeyCredentialsView(

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/ApiKeyServiceImpl.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/ApiKeyServiceImpl.kt
@@ -1,0 +1,76 @@
+package com.epam.drill.admin.auth.service.impl
+
+import com.epam.drill.admin.auth.entity.ApiKeyEntity
+import com.epam.drill.admin.auth.model.ApiKeyCredentialsView
+import com.epam.drill.admin.auth.model.ApiKeyView
+import com.epam.drill.admin.auth.model.GenerateApiKeyPayload
+import com.epam.drill.admin.auth.model.UserApiKeyView
+import com.epam.drill.admin.auth.principal.Role
+import com.epam.drill.admin.auth.repository.ApiKeyRepository
+import com.epam.drill.admin.auth.service.ApiKeyService
+import com.epam.drill.admin.auth.service.PasswordService
+import kotlinx.datetime.toKotlinLocalDateTime
+import java.security.SecureRandom
+import java.time.LocalDateTime
+import java.util.*
+
+class ApiKeyServiceImpl(
+    private val repository: ApiKeyRepository,
+    private val passwordService: PasswordService
+): ApiKeyService {
+    override suspend fun getAllApiKeys(): List<ApiKeyView> {
+        return repository.getAll()
+            .map { it.toApiKeyView() }
+    }
+
+    override suspend fun getApiKeysByUser(userId: Int): List<UserApiKeyView> {
+        return repository.getAllByUserId(userId)
+            .map { it.toUserApiKeyView() }
+    }
+
+    override suspend fun deleteApiKey(id: Int) {
+        repository.deleteById(id)
+    }
+
+    override suspend fun generateApiKey(userId: Int, payload: GenerateApiKeyPayload): ApiKeyCredentialsView {
+        val apiKey = generateKey()
+        val apiKeyHash = passwordService.hashPassword(apiKey)
+        val entity = ApiKeyEntity(
+            userId = userId,
+            description = payload.description,
+            apiKeyHash = apiKeyHash,
+            expiresAt = LocalDateTime.now().plusMonths(payload.expiryPeriod.months.toLong()),
+            createdAt = LocalDateTime.now()
+        )
+        val entityWithId = repository.create(entity)
+        return ApiKeyCredentialsView(
+            id = entityWithId.id ?: throw NullPointerException("Api key id cannot be null after creation"),
+            apiKey = entityWithId.apiKeyHash,
+            expiresAt = entityWithId.expiresAt.toKotlinLocalDateTime()
+        )
+    }
+
+    private fun generateKey(): String {
+        val random = SecureRandom()
+        val keyBytes = ByteArray(32)
+        random.nextBytes(keyBytes)
+        return Base64.getEncoder().encodeToString(keyBytes)
+    }
+}
+
+private fun ApiKeyEntity.toApiKeyView() = ApiKeyView(
+    id = id ?: throw NullPointerException("Api Key id cannot be null"),
+    userId = userId,
+    description = description,
+    expiresAt = expiresAt.toKotlinLocalDateTime(),
+    createdAt = createdAt.toKotlinLocalDateTime(),
+    username = user?.username ?: throw NullPointerException("User property cannot be null in ApiKeyEntity"),
+    role = user.role.let { Role.valueOf(it) },
+)
+
+private fun ApiKeyEntity.toUserApiKeyView() = UserApiKeyView(
+    id = id ?: throw NullPointerException("Api Key id cannot be null"),
+    description = description,
+    expiresAt = expiresAt.toKotlinLocalDateTime(),
+    createdAt = createdAt.toKotlinLocalDateTime(),
+)

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/UserManagementServiceImpl.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/impl/UserManagementServiceImpl.kt
@@ -33,11 +33,11 @@ class UserManagementServiceImpl(
     private val externalRoleManagement: Boolean = false
 ) : UserManagementService {
     override suspend fun getUsers(): List<UserView> {
-        return userRepository.findAll().map { it.toView() }
+        return userRepository.findAll().map { it.toApiKeyView() }
     }
 
     override suspend fun getUser(userId: Int): UserView {
-        return findUser(userId).toView()
+        return findUser(userId).toApiKeyView()
     }
 
     override suspend fun updateUser(userId: Int, payload: EditUserPayload): UserView {
@@ -45,7 +45,7 @@ class UserManagementServiceImpl(
         if (externalRoleManagement && oldUserEntity.external)
             throw ForbiddenOperationException("Cannot update role for external user")
         val updatedUserEntity = userRepository.update(payload.toEntity(oldUserEntity))
-        return updatedUserEntity.toView()
+        return updatedUserEntity.toApiKeyView()
     }
 
     override suspend fun deleteUser(userId: Int) {
@@ -82,7 +82,7 @@ private fun UserEntity.toCredentialsView(newPassword: String): CredentialsView {
     )
 }
 
-private fun UserEntity.toView(): UserView {
+private fun UserEntity.toApiKeyView(): UserView {
     return UserView(
         id = this.id ?: throw NullPointerException("User id cannot be null"),
         username = this.username,

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/transaction/TransactionalApiKeyService.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/service/transaction/TransactionalApiKeyService.kt
@@ -1,0 +1,24 @@
+package com.epam.drill.admin.auth.service.transaction
+
+import com.epam.drill.admin.auth.model.GenerateApiKeyPayload
+import com.epam.drill.admin.auth.service.ApiKeyService
+import com.epam.drill.admin.auth.config.DatabaseConfig.transaction
+
+class TransactionalApiKeyService(private val delegate: ApiKeyService
+) : ApiKeyService by delegate {
+    override suspend fun getAllApiKeys() = transaction {
+        delegate.getAllApiKeys()
+    }
+
+    override suspend fun getApiKeysByUser(userId: Int) = transaction {
+        delegate.getApiKeysByUser(userId)
+    }
+
+    override suspend fun deleteApiKey(id: Int) = transaction {
+        delegate.deleteApiKey(id)
+    }
+
+    override suspend fun generateApiKey(userId: Int, payload: GenerateApiKeyPayload) = transaction {
+        delegate.generateApiKey(userId, payload)
+    }
+}

--- a/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/table/ApiKeyTable.kt
+++ b/admin-auth/src/main/kotlin/com/epam/drill/admin/auth/table/ApiKeyTable.kt
@@ -1,0 +1,12 @@
+package com.epam.drill.admin.auth.table
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.javatime.datetime
+
+object ApiKeyTable : IntIdTable(name = "auth.api_key") {
+    val userId = integer("user_id").references(UserTable.id)
+    val description = varchar("description", 200)
+    val apiKeyHash = varchar("api_key_hash", 100)
+    var expiresAt = datetime("expires_at")
+    var createdAt = datetime("created_at")
+}

--- a/admin-auth/src/main/resources/auth/db/migration/V2__Api_keys_init.sql
+++ b/admin-auth/src/main/resources/auth/db/migration/V2__Api_keys_init.sql
@@ -1,0 +1,10 @@
+CREATE TABLE auth.api_key (
+  id serial PRIMARY KEY,
+  user_id INTEGER REFERENCES auth.user (id) NOT NULL,
+  description VARCHAR (200) NOT NULL,
+  api_key_hash VARCHAR (100) NOT NULL,
+  expires_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+  created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL
+);
+
+CREATE INDEX api_key_user_id_idx ON auth.api_key (user_id);

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/DatabaseApiKeyRepositoryTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/DatabaseApiKeyRepositoryTest.kt
@@ -1,64 +1,23 @@
 package com.epam.drill.admin.auth
 
-import com.epam.drill.admin.auth.config.DatabaseConfig
 import com.epam.drill.admin.auth.entity.ApiKeyEntity
 import com.epam.drill.admin.auth.principal.Role
 import com.epam.drill.admin.auth.repository.impl.DatabaseApiKeyRepository
 import com.epam.drill.admin.auth.table.ApiKeyTable
 import com.epam.drill.admin.auth.table.UserTable
-import com.zaxxer.hikari.HikariConfig
-import com.zaxxer.hikari.HikariDataSource
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.sql.insertAndGetId
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.statements.InsertStatement
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
-import org.testcontainers.utility.DockerImageName
 import java.time.LocalDateTime
 import java.time.Month
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-@Testcontainers
-class DatabaseApiKeyRepositoryTest {
+class DatabaseApiKeyRepositoryTest: DatabaseTests() {
     private val repository = DatabaseApiKeyRepository()
-
-    companion object {
-        @Container
-        private val postgresqlContainer = PostgreSQLContainer<Nothing>(
-            DockerImageName.parse("postgres:14.1")
-        ).apply {
-            withDatabaseName("testdb")
-            withUsername("testuser")
-            withPassword("testpassword")
-        }
-
-        @JvmStatic
-        @BeforeAll
-        fun setup() {
-            postgresqlContainer.start()
-            val dataSource = HikariDataSource(HikariConfig().apply {
-                this.jdbcUrl = postgresqlContainer.jdbcUrl
-                this.username = postgresqlContainer.username
-                this.password = postgresqlContainer.password
-                this.driverClassName = postgresqlContainer.driverClassName
-                this.validate()
-            })
-            DatabaseConfig.init(dataSource)
-        }
-
-        @JvmStatic
-        @AfterAll
-        fun finish() {
-            postgresqlContainer.stop()
-        }
-    }
 
     @Test
     fun `given api-key entity, create must insert api-key and return api-key entity with id`() = withTransaction {

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/DatabaseApiKeyRepositoryTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/DatabaseApiKeyRepositoryTest.kt
@@ -1,0 +1,125 @@
+package com.epam.drill.admin.auth
+
+import com.epam.drill.admin.auth.config.DatabaseConfig
+import com.epam.drill.admin.auth.entity.ApiKeyEntity
+import com.epam.drill.admin.auth.repository.impl.DatabaseApiKeyRepository
+import com.epam.drill.admin.auth.table.ApiKeyTable
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.statements.InsertStatement
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import java.time.LocalDateTime
+import java.time.Month
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Testcontainers
+class DatabaseApiKeyRepositoryTest {
+    private val repository = DatabaseApiKeyRepository()
+
+    companion object {
+        @Container
+        private val postgresqlContainer = PostgreSQLContainer<Nothing>(
+            DockerImageName.parse("postgres:14.1")
+        ).apply {
+            withDatabaseName("testdb")
+            withUsername("testuser")
+            withPassword("testpassword")
+        }
+
+        @JvmStatic
+        @BeforeAll
+        fun setup() {
+            postgresqlContainer.start()
+            val dataSource = HikariDataSource(HikariConfig().apply {
+                this.jdbcUrl = postgresqlContainer.jdbcUrl
+                this.username = postgresqlContainer.username
+                this.password = postgresqlContainer.password
+                this.driverClassName = postgresqlContainer.driverClassName
+                this.validate()
+            })
+            DatabaseConfig.init(dataSource)
+        }
+    }
+
+    @Test
+    fun `given api-key entity, create must insert api-key and return api-key entity with id`() = withTransaction {
+        val testUserId = insertUser()
+        val apiKeyEntity = ApiKeyEntity(
+            description = "for testing",
+            apiKeyHash = "hash",
+            userId = testUserId,
+            expiresAt = LocalDateTime.of(2024, Month.JANUARY, 1, 0, 0),
+            createdAt = LocalDateTime.of(2023, Month.JANUARY, 1, 0, 0)
+        )
+
+        val createdApiKeyEntity = repository.create(apiKeyEntity)
+
+        assertEquals(1, ApiKeyTable.select { ApiKeyTable.id eq createdApiKeyEntity.id }.count())
+    }
+
+    @Test
+    fun `given userId, getAllByUserId must return all api-keys of this user`() = withTransaction {
+        val userId1 = insertUser()
+        val userId2 = insertUser()
+        insertApiKey { it[userId] = userId1 }
+        insertApiKey { it[userId] = userId1 }
+        insertApiKey { it[userId] = userId2 }
+
+        val apiKeysByUserId1 = repository.getAllByUserId(userId1)
+        val apiKeysByUserId2 = repository.getAllByUserId(userId2)
+
+        assertEquals(2, apiKeysByUserId1.size)
+        assertEquals(1, apiKeysByUserId2.size)
+    }
+
+    @Test
+    fun `getAll must return all api-keys of all users`() = withTransaction {
+        val userId1 = insertUser()
+        val userId2 = insertUser()
+        insertApiKey { it[userId] = userId1 }
+        insertApiKey { it[userId] = userId1 }
+        insertApiKey { it[userId] = userId2 }
+
+        val allApiKeys = repository.getAll()
+
+        assertEquals(3, allApiKeys.size)
+    }
+
+    @Test
+    fun `given api-key id, delete must remove this api-key`() = withTransaction {
+        val testUserId = insertUser()
+        val testApiKeyId = insertApiKey { it[userId] = testUserId }
+
+        repository.delete(testApiKeyId)
+
+        assertEquals(0, ApiKeyTable.select { ApiKeyTable.id eq testApiKeyId }.count())
+    }
+}
+
+private fun withTransaction(test: suspend () -> Unit) {
+    runBlocking {
+        newSuspendedTransaction {
+            test()
+            rollback()
+        }
+    }
+}
+
+fun insertApiKey(overrideColumns: ApiKeyTable.(InsertStatement<*>) -> Unit = {}) =
+    ApiKeyTable.insertAndGetId {
+        it[description] = "for testing"
+        it[apiKeyHash] = "hash"
+        it[expiresAt] = LocalDateTime.now().plusYears(1)
+        it[createdAt] = LocalDateTime.now()
+        overrideColumns(it)
+    }.value

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/DatabaseApiKeyRepositoryTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/DatabaseApiKeyRepositoryTest.kt
@@ -109,9 +109,32 @@ class DatabaseApiKeyRepositoryTest {
         val testUserId = insertUser()
         val testApiKeyId = insertApiKey { it[userId] = testUserId }
 
-        repository.delete(testApiKeyId)
+        repository.deleteById(testApiKeyId)
 
         assertEquals(0, ApiKeyTable.select { ApiKeyTable.id eq testApiKeyId }.count())
+    }
+
+
+    @Test
+    fun `getAll must return not null user entity in every api-key entity`() = withTransaction {
+        val testUserId = insertUser()
+        insertApiKey { it[userId] = testUserId }
+        insertApiKey { it[userId] = testUserId }
+
+        val allApiKeys = repository.getAll()
+
+        assertTrue(allApiKeys.all { it.user != null })
+    }
+
+    @Test
+    fun `getAllByUserId must return null user entity in every api-key entity`() = withTransaction {
+        val testUserId = insertUser()
+        insertApiKey { it[userId] = testUserId }
+        insertApiKey { it[userId] = testUserId }
+
+        val apiKeys = repository.getAllByUserId(testUserId)
+
+        assertTrue(apiKeys.all { it.user == null })
     }
 }
 

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/DatabaseUserRepositoryTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/DatabaseUserRepositoryTest.kt
@@ -39,7 +39,7 @@ import java.time.Month
 import kotlin.test.*
 
 @Testcontainers
-class UserRepositoryImplTest {
+class DatabaseUserRepositoryTest {
 
     private val repository = DatabaseUserRepository()
 
@@ -275,7 +275,7 @@ private fun insertUsers(
     return ids
 }
 
-private fun insertUser(index: Int = 1, overrideColumns: UserTable.(InsertStatement<*>) -> Unit = {}) =
+fun insertUser(index: Int = 1, overrideColumns: UserTable.(InsertStatement<*>) -> Unit = {}) =
     UserTable.insertAndGetId {
         it[username] = "username$index"
         it[passwordHash] = "hash$index"

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/DatabaseUserRepositoryTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/DatabaseUserRepositoryTest.kt
@@ -27,6 +27,7 @@ import org.jetbrains.exposed.sql.insertAndGetId
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.statements.InsertStatement
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -65,6 +66,12 @@ class DatabaseUserRepositoryTest {
                 this.validate()
             })
             DatabaseConfig.init(dataSource)
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun finish() {
+            postgresqlContainer.stop()
         }
     }
 
@@ -259,8 +266,11 @@ class DatabaseUserRepositoryTest {
 private fun withTransaction(test: suspend () -> Unit) {
     runBlocking {
         newSuspendedTransaction {
-            test()
-            rollback()
+            try {
+                test()
+            } finally {
+                rollback()
+            }
         }
     }
 }

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/DatabaseUserRepositoryTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/DatabaseUserRepositoryTest.kt
@@ -285,7 +285,7 @@ private fun insertUsers(
     return ids
 }
 
-fun insertUser(index: Int = 1, overrideColumns: UserTable.(InsertStatement<*>) -> Unit = {}) =
+private fun insertUser(index: Int = 1, overrideColumns: UserTable.(InsertStatement<*>) -> Unit = {}) =
     UserTable.insertAndGetId {
         it[username] = "username$index"
         it[passwordHash] = "hash$index"

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/DatabaseUserRepositoryTest.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/DatabaseUserRepositoryTest.kt
@@ -15,65 +15,24 @@
  */
 package com.epam.drill.admin.auth
 
-import com.epam.drill.admin.auth.config.DatabaseConfig
 import com.epam.drill.admin.auth.entity.UserEntity
 import com.epam.drill.admin.auth.principal.Role
 import com.epam.drill.admin.auth.repository.impl.DatabaseUserRepository
 import com.epam.drill.admin.auth.table.UserTable
-import com.zaxxer.hikari.HikariConfig
-import com.zaxxer.hikari.HikariDataSource
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.sql.insertAndGetId
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.statements.InsertStatement
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
-import org.testcontainers.utility.DockerImageName
 import java.time.LocalDateTime
 import java.time.Month
 import kotlin.test.*
 
-@Testcontainers
-class DatabaseUserRepositoryTest {
+class DatabaseUserRepositoryTest: DatabaseTests() {
 
     private val repository = DatabaseUserRepository()
-
-    companion object {
-        @Container
-        private val postgresqlContainer = PostgreSQLContainer<Nothing>(
-            DockerImageName.parse("postgres:14.1")
-        ).apply {
-            withDatabaseName("testdb")
-            withUsername("testuser")
-            withPassword("testpassword")
-        }
-
-        @JvmStatic
-        @BeforeAll
-        fun setup() {
-            postgresqlContainer.start()
-            val dataSource = HikariDataSource(HikariConfig().apply {
-                this.jdbcUrl = postgresqlContainer.jdbcUrl
-                this.username = postgresqlContainer.username
-                this.password = postgresqlContainer.password
-                this.driverClassName = postgresqlContainer.driverClassName
-                this.validate()
-            })
-            DatabaseConfig.init(dataSource)
-        }
-
-        @JvmStatic
-        @AfterAll
-        fun finish() {
-            postgresqlContainer.stop()
-        }
-    }
 
     @Test
     fun `given unique username, create must insert user and return user entity with id`() = withTransaction {

--- a/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/TestUtils.kt
+++ b/admin-auth/src/test/kotlin/com/epam/drill/admin/auth/TestUtils.kt
@@ -20,6 +20,7 @@ import com.auth0.jwt.JWTCreator
 import com.auth0.jwt.algorithms.Algorithm
 import com.epam.drill.admin.auth.config.CLAIM_ROLE
 import com.epam.drill.admin.auth.config.CLAIM_USER_ID
+import com.epam.drill.admin.auth.entity.ApiKeyEntity
 import com.epam.drill.admin.auth.entity.UserEntity
 import com.epam.drill.admin.auth.model.DataResponse
 import com.epam.drill.admin.auth.principal.Role
@@ -131,6 +132,10 @@ object CopyUserWithID : Answer<UserEntity> {
 
 object CopyUser : Answer<UserEntity> {
     override fun answer(invocation: InvocationOnMock?) = invocation?.getArgument<UserEntity>(0)?.copy()
+}
+
+fun copyApiKeyWithId(id: Int) = Answer<ApiKeyEntity> { invocation ->
+    invocation?.getArgument<ApiKeyEntity>(0)?.copy(id = id)
 }
 
 fun Authentication.Configuration.jwtMock() {


### PR DESCRIPTION
Should be discussed:
I decided that the ApiKeyView for management purposes should contain information about the username, user role, etc., but the UserApiKeyView should not because they are already in the context of the current user.
So I added a nullable user field to the ApiKeyEntity. For management purposes, api_key table will be joined with the user table in the database, but in case of user purposes it will not be. This is for SQL optimization.